### PR TITLE
refactor: remove goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python3 setup.py install
 Installing this plugin adds support for the Base ecosystem:
 
 ```
-ape console --network base:goerli 
+ape console --network base:sepolia
 ```
 
 ## Development

--- a/ape_base/ecosystem.py
+++ b/ape_base/ecosystem.py
@@ -14,7 +14,6 @@ from ape_optimism import Optimism, OptimismConfig
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (8453, 8453),
-    "goerli": (84531, 84531),
     "sepolia": (84532, 84532),
 }
 _SECOND_STATIC_TYPE = 126
@@ -23,9 +22,6 @@ _SECOND_STATIC_TYPE = 126
 class BaseConfig(OptimismConfig):
     DEFAULT_TRANSACTION_TYPE: ClassVar[int] = TransactionType.STATIC.value
     mainnet: NetworkConfig = create_network_config(
-        block_time=2, default_transaction_type=TransactionType.STATIC
-    )
-    goerli: NetworkConfig = create_network_config(
         block_time=2, default_transaction_type=TransactionType.STATIC
     )
     sepolia: NetworkConfig = create_network_config(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,8 +6,6 @@ EXPECTED_OUTPUT = """
 base
 ├── mainnet
 │   └── geth  (default)
-├── goerli
-│   └── geth  (default)
 ├── sepolia
 │   └── geth  (default)
 └── local  (default)
@@ -49,7 +47,6 @@ def assert_rich_text(actual: str, expected: str):
 def test_networks(runner, cli, base):
     # Do this in case local env changed it.
     base.mainnet.set_default_provider("geth")
-    base.goerli.set_default_provider("geth")
     base.sepolia.set_default_provider("geth")
 
     result = runner.invoke(cli, ["networks", "list"])


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
