### PR TITLE
refactor: harmonize ape-base plugin with ape-optimism

### DIFF
--- a/ape_base/__init__.py
+++ b/ape_base/__init__.py
@@ -3,14 +3,14 @@ from ape import plugins
 
 @plugins.register(plugins.Config)
 def config_class():
-    from ape_base.ecosystem import BaseConfig
+    from .ecosystem import BaseConfig
 
     return BaseConfig
 
 
 @plugins.register(plugins.EcosystemPlugin)
 def ecosystems():
-    from ape_base.ecosystem import Base
+    from .ecosystem import Base
 
     yield Base
 
@@ -24,7 +24,7 @@ def networks():
         create_network_type,
     )
 
-    from ape_base.ecosystem import NETWORKS
+    from .ecosystem import NETWORKS
 
     for network_name, network_params in NETWORKS.items():
         yield "base", network_name, create_network_type(*network_params)
@@ -50,17 +50,17 @@ def providers():
 
 def __getattr__(name: str):
     if name == "NETWORKS":
-        from ape_base.ecosystem import NETWORKS
+        from .ecosystem import NETWORKS
 
         return NETWORKS
 
     elif name == "Base":
-        from ape_base.ecosystem import Base
+        from .ecosystem import Base
 
         return Base
 
     elif name == "BaseConfig":
-        from ape_base.ecosystem import BaseConfig
+        from .ecosystem import BaseConfig
 
         return BaseConfig
 

--- a/ape_base/ecosystem.py
+++ b/ape_base/ecosystem.py
@@ -1,161 +1,25 @@
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import cast
 
-from ape.types import TransactionSignature
 from ape_ethereum.ecosystem import NetworkConfig, create_network_config
-from ape_ethereum.transactions import (
-    AccessListTransaction,
-    DynamicFeeTransaction,
-    StaticFeeTransaction,
-    TransactionType,
-)
 from ape_optimism import Optimism, OptimismConfig
-
-if TYPE_CHECKING:
-    from ape.api import TransactionAPI
 
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (8453, 8453),
     "sepolia": (84532, 84532),
 }
-_SECOND_STATIC_TYPE = 126
 
 
 class BaseConfig(OptimismConfig):
-    DEFAULT_TRANSACTION_TYPE: ClassVar[int] = TransactionType.STATIC.value
-    mainnet: NetworkConfig = create_network_config(
-        block_time=2, default_transaction_type=TransactionType.STATIC
-    )
-    sepolia: NetworkConfig = create_network_config(
-        block_time=2, default_transaction_type=TransactionType.STATIC
-    )
+    mainnet: NetworkConfig = create_network_config(block_time=2)
+    sepolia: NetworkConfig = create_network_config(block_time=2)
 
 
-# NOTE: Since base is built on Optimism, we use Optimism as the base class.
 class Base(Optimism):
+    """
+    Base is built on the OP-Stack, so `Base` inherits directly from `Optimism`.
+    """
+
     @property
     def config(self) -> BaseConfig:  # type: ignore
         return cast(BaseConfig, self.config_manager.get_config("base"))
-
-    def create_transaction(self, **kwargs) -> "TransactionAPI":
-        """
-        Returns a transaction using the given constructor kwargs.
-        Overridden to support custom type.
-
-        **kwargs: Kwargs for the transaction class.
-
-        Returns:
-            :class:`~ape.api.transactions.TransactionAPI`
-        """
-
-        # Handle all aliases.
-        tx_data = dict(kwargs)
-        tx_data = _correct_key(
-            "max_priority_fee",
-            tx_data,
-            ("max_priority_fee_per_gas", "maxPriorityFeePerGas", "maxPriorityFee"),
-        )
-        tx_data = _correct_key("max_fee", tx_data, ("max_fee_per_gas", "maxFeePerGas", "maxFee"))
-        tx_data = _correct_key("gas", tx_data, ("gas_limit", "gasLimit"))
-        tx_data = _correct_key("gas_price", tx_data, ("gasPrice",))
-        tx_data = _correct_key(
-            "type",
-            tx_data,
-            ("txType", "tx_type", "txnType", "txn_type", "transactionType", "transaction_type"),
-        )
-
-        # Handle unique value specifications, such as "1 ether".
-        if "value" in tx_data and not isinstance(tx_data["value"], int):
-            value = tx_data["value"] or 0  # Convert None to 0.
-            tx_data["value"] = self.conversion_manager.convert(value, int)
-
-        # None is not allowed, the user likely means `b""`.
-        if "data" in tx_data and tx_data["data"] is None:
-            tx_data["data"] = b""
-
-        # Deduce the transaction type.
-        transaction_types: dict[int, type["TransactionAPI"]] = {
-            TransactionType.STATIC.value: StaticFeeTransaction,
-            TransactionType.DYNAMIC.value: DynamicFeeTransaction,
-            TransactionType.ACCESS_LIST.value: AccessListTransaction,
-            _SECOND_STATIC_TYPE: StaticFeeTransaction,
-        }
-
-        if "type" in tx_data:
-            if tx_data["type"] is None:
-                # Explicit `None` means used default.
-                version = self.default_transaction_type.value
-            elif isinstance(tx_data["type"], TransactionType):
-                version = tx_data["type"].value
-            elif isinstance(tx_data["type"], int):
-                version = tx_data["type"]
-            else:
-                # Using hex values or alike.
-                version = self.conversion_manager.convert(tx_data["type"], int)
-
-        elif "gas_price" in tx_data:
-            version = TransactionType.STATIC.value
-        elif "max_fee" in tx_data or "max_priority_fee" in tx_data:
-            version = TransactionType.DYNAMIC.value
-        elif "access_list" in tx_data or "accessList" in tx_data:
-            version = TransactionType.ACCESS_LIST.value
-        else:
-            version = self.default_transaction_type.value
-
-        tx_data["type"] = version
-
-        # This causes problems in pydantic for some reason.
-        # NOTE: This must happen after deducing the tx type!
-        if "gas_price" in tx_data and tx_data["gas_price"] is None:
-            del tx_data["gas_price"]
-
-        txn_class = transaction_types[version]
-
-        if "required_confirmations" not in tx_data or tx_data["required_confirmations"] is None:
-            # Attempt to use default required-confirmations from `ape-config.yaml`.
-            required_confirmations = 0
-            active_provider = self.network_manager.active_provider
-            if active_provider:
-                required_confirmations = active_provider.network.required_confirmations
-
-            tx_data["required_confirmations"] = required_confirmations
-
-        if isinstance(tx_data.get("chainId"), str):
-            tx_data["chainId"] = int(tx_data["chainId"], 16)
-
-        elif (
-            "chainId" not in tx_data or tx_data["chainId"] is None
-        ) and self.network_manager.active_provider is not None:
-            tx_data["chainId"] = self.provider.chain_id
-
-        if "input" in tx_data:
-            tx_data["data"] = tx_data.pop("input")
-
-        if all(field in tx_data for field in ("v", "r", "s")):
-            tx_data["signature"] = TransactionSignature(
-                v=tx_data["v"],
-                r=bytes(tx_data["r"]),
-                s=bytes(tx_data["s"]),
-            )
-
-        if "gas" not in tx_data:
-            tx_data["gas"] = None
-
-        return txn_class(**tx_data)
-
-
-def _correct_key(key: str, data: dict, alt_keys: tuple[str, ...]) -> dict:
-    if key in data:
-        return data
-
-    # Check for alternative.
-    for possible_key in alt_keys:
-        if possible_key not in data:
-            continue
-
-        # Alt found: use it.
-        new_data = {k: v for k, v in data.items() if k not in alt_keys}
-        new_data[key] = data[possible_key]
-        return new_data
-
-    return data


### PR DESCRIPTION
### What I did

I noticed that EIP-7702 tests were failing because of validation errors when run against a Base mainnet fork. Type 4 transactions were not included in `ecosystem.py`, so I reviewed the inherited class from ape-optimism and found that the ecosystem could simply reuse the methods from the `Optimism` class. 

Inheriting directly from Optimism gives automatic access to Type 4 transactions from ape-ethereum, and reduces maintenance overhead since Base is built on the OP Stack.

EIP-7702 is included in Base since the Isthmus hardfork.

The refactor also matches Base to the Optimism default transaction type (EIP-1559), which can help during periods of high load. I have had several contract deployments get stuck when the default was Type 0, and resorted to overriding the transaction type to compensate.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
